### PR TITLE
Improve communication speed

### DIFF
--- a/cl-redis.asd
+++ b/cl-redis.asd
@@ -9,7 +9,7 @@
   :maintainer "Vsevolod Dyomkin <vseloved@gmail.com>"
   :licence "MIT"
   :description "A fast and robust Common Lisp client for Redis"
-  :depends-on (#:rutils #:cl-ppcre #:usocket #:flexi-streams)
+  :depends-on (#:rutils #:cl-ppcre #:usocket #:flexi-streams #:babel)
   :serial t
   :components ((:file "package")
                (:file "float")

--- a/test.lisp
+++ b/test.lisp
@@ -1021,7 +1021,7 @@
     (should be string= "redis_version"
             (let ((info (red:info)))
               (if (char= #\# (char info 0))
-                  (sub info 9 22)
+                  (sub info 10 23)
                   (sub info 0 13))))
     (should be string= "OK"
             (red:slaveof "no" "one"))


### PR DESCRIPTION
First of all, a disclaimer. I'm only evaluating redis, and have almost no experience with it yet.

This patch resulted from the desire to make cl-redis faster than Ruby redis in the benchmark at http://redis.io/topics/pipelining. You can see benchmark results (seconds after three runs, and allocated memory) at https://github.com/orivej/cl-redis/blob/bench/bench.org.

All tests still pass, but redis_version test had to be adjusted for `red-info` now returning `#\Return#\Newline`-separated lines, because it is defined as a bulk-output command, and they don't deform strings in the patched version anymore. This is an incompatible change: if in the original version of cl-redis I put a value of `A#\Return#\NewlineB`, it will be stored as `A\r\r\nB`, and in the patched version returned as `A#\Return#\Return#\NewlineB`. Backwards compatible but slower patch is in the [flex](https://github.com/orivej/cl-redis/tree/flex) branch.
