### PR TITLE
strings inside objects get converted to symbols

### DIFF
--- a/redis.lisp
+++ b/redis.lisp
@@ -30,7 +30,7 @@ If *ECHOP-P* is not NIL, write that string to *ECHO-STREAM*, too."
   (typecase obj
     (string obj)
     (symbol (string obj))
-    (t (princ-to-string obj))))
+    (t (prin1-to-string obj))))
 
 ;;; Conditions
 


### PR DESCRIPTION
On insertion of Lisp objects, strings are inserted as symbols, because
'princ-to-string' won't enclose strings with quotation marks.

for example:
```
CL-USER> (red:set "test" '("foo" "bar"))
> "OK"
CL-USER> (red:get "test")
> "(foo bar)"
```

but it should be:
```
> "(\"foo\" \"bar\")"
```

thats because:
```
CL-USER> (princ-to-string '("foo" "bar")) ; which is used
> "(foo bar)"
CL-USER> (prin1-to-string '("foo" "bar")) ; which should be used
> "(\"foo\" \"bar\")"
```

The problem is that it's not possible to save a lisp datastructure
(contaning strings) and read it back with 'read-from-string'.
This commit replaces the 'princ-to-string' with 'prin1-to-string' to
fix the problem.