### PR TITLE
Throwing redis-connection-error if no connection established

### DIFF
--- a/connection.lisp
+++ b/connection.lisp
@@ -47,6 +47,10 @@ for debugging purposes.  The default is *STANDARD-OUTPUT*.")
 (defmethod initialize-instance :after ((conn redis-connection) &key)
   (open-connection conn))
 
+(defmethod conn-stream ((object null))
+  (error 'redis-connection-error
+	 :error "No connection to Redis server was not established."))
+
 (defun connection-open-p (conn)
   "Is the socket of CONNECTION open?"
   (and-it (conn-stream conn)


### PR DESCRIPTION
I've tried cl-redis and this works well. 
But I occasionally call cl-redis functions before establishing any connection. In this situation, cl-redis throws `NO-APPLICABLE-METHOD` error and surprises me.

> There is no applicable method for the generic function
>   #<STANDARD-GENERIC-FUNCTION REDIS::CONN-STREAM (1)>
> when called with arguments
>   (NIL).
>    [Condition of type SB-PCL::NO-APPLICABLE-METHOD-ERROR]
> See also:
>   Common Lisp Hyperspec, 7.6.6 [:section]
> 
> Restarts:
>  0: [RETRY] Retry calling the generic function.
>  1: [RETRY] Retry SLIME REPL evaluation request.
>  2: [*ABORT] Return to SLIME's top level.
>  3: [ABORT] abort thread (#<THREAD "repl-thread" RUNNING {10021E8003}>)
> 
> Backtrace:
>   0: ((:METHOD NO-APPLICABLE-METHOD (T)) #<STANDARD-GENERIC-FUNCTION REDIS::CONN-STREAM (1)> NIL) [fast-method]
>   1: (SB-PCL::CALL-NO-APPLICABLE-METHOD #<STANDARD-GENERIC-FUNCTION REDIS::CONN-STREAM (1)> (NIL))
>   2: (REDIS::FORMAT-REDIS-NUMBER #\* 2)
>   3: ((:METHOD REDIS:TELL (T)) REDIS::GET "hey") [fast-method]
>   4: ((SB-PCL::EMF REDIS:TELL) #<unused argument> #<unused argument> REDIS::GET "hey")
>   5: (REDIS::GET "hey")
>   6: (SB-INT:SIMPLE-EVAL-IN-LEXENV (REDIS::GET "hey") #<NULL-LEXENV>)
>   7: (EVAL (REDIS::GET "hey"))
>  --more--

This pull request replaces the condition with `redis-connection-error`. I think this provides more information about what to do.

> Redis error: No connection to Redis server was not established.
>    [Condition of type REDIS:REDIS-CONNECTION-ERROR]
> 
> Restarts:
>  0: [RETRY] Retry SLIME REPL evaluation request.
>  1: [*ABORT] Return to SLIME's top level.
>  2: [ABORT] abort thread (#<THREAD "repl-thread" RUNNING {10021E8003}>)


Thank you for reading to the end.