### PR TITLE
Fixing a symbol conflict between cl-redis and rutils.

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -7,7 +7,7 @@
 (defpackage #:redis
   (:use #:common-lisp #:rutil)
   (:shadow #:quit #:sort #:set #:get #:substr #:eval #:type #:append
-           #:watch #:unwatch #:shutdown #:time)
+           #:watch #:unwatch #:shutdown #:time #:keys)
   (:export #:redis-connection
            #:connect
            #:disconnect


### PR DESCRIPTION
This pull request tries to fix a building problem of cl-redis with rutis version 5.

`RUTILS:KEYS` is exported from `RUTILS.KV` package and `RUTILS` package (using `re-export-symbols`), and the symbol has a method.
However, `REDIS::KEYS` is fbound by `defun` in commands.lisp.

So, I think `redis` package should shadow "KEYS" symbol for its use. Commit e09b9aa does it.

____

Curiously, this error does not raised by `asdf:load-system` or `ql:quickload`. I saw this error when I built a monolithic fasl.
I paste a procedure for reproducing on SBCL 1.5.8 on MacOS X below:

```
~$ sbcl
sbcl
This is SBCL 1.5.8, an implementation of ANSI Common Lisp.
More information about SBCL is available at <http://www.sbcl.org/>.

[...]

* (ql:quickload "cl-redis")
(ql:quickload "cl-redis")
To load "cl-redis":
  Load 1 ASDF system:
    cl-redis
; Loading "cl-redis"

[...]

("cl-redis")

* (asdf:operate 'asdf:monolithic-compile-bundle-op :cl-redis)
(asdf:operate 'asdf:monolithic-compile-bundle-op :cl-redis)
#<ASDF/BUNDLE:MONOLITHIC-COMPILE-BUNDLE-OP >
#<ASDF/PLAN:SEQUENTIAL-PLAN {1001870F13}>

* (asdf:output-files 'asdf:monolithic-compile-bundle-op :cl-redis)
(asdf:output-files 'asdf:monolithic-compile-bundle-op :cl-redis)
(#P"/Users/yokota/.cache/common-lisp/sbcl-1.5.8-macosx-x64/Users/yokota/quicklisp/dists/quicklisp/software/cl-redis-20180711-git/cl-redis--all-systems.fasl")
T

* (load (first *))

[...]

STYLE-WARNING: VOID was previously defined as a macro.
STYLE-WARNING:
   VOID is being redefined as a macro when it was previously assumed to be a function.
WARNING: redefining RUTILS.MISC:VOID in DEFMACRO
WARNING: redefining RUTILS.KV:KEYS in DEFGENERIC

debugger invoked on a SB-INT:SIMPLE-PROGRAM-ERROR in thread
#<THREAD "main thread" RUNNING {10005084C3}>:
  RUTILS.KV:KEYS already names an ordinary function or a macro.

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [CONTINUE] Replace the function binding
  1: [ABORT   ] Exit debugger, returning to top level.

(ENSURE-GENERIC-FUNCTION KEYS :LAMBDA-LIST (KV) SB-PCL::SOURCE #S(SB-C:DEFINITION-SOURCE-LOCATION :NAMESTRING "/Users/yokota/quicklisp/dists/quicklisp/software/rutils-20191007-git/core/kv.lisp" :INDICES 131073) :DOCUMENTATION "Return a list of all keys in a KV.
    Order is unspecified.")
0] 
```

(I suspect this is because`def-cmd` constructs a package dynamically using `cl:export`.)
 
