### PR TITLE
add bitfield, bitfield_ro

### DIFF
--- a/commands.lisp
+++ b/commands.lisp
@@ -338,6 +338,13 @@ Warning: left for backwards compatibility. It is now called: GETRANGE.")
   "Count set bits in a string at KEY
 \(with optional bounding indices START and END).")
 
+(def-cmd BITFIELD (key &rest args) :multi
+  "Treats a Redis string as an array of bits, takes a list of
+\operations, returns an array of replies.")
+
+(def-cmd BITFIELD_RO (key &rest args) :multi
+  "Read-only variant of BITFIELD")
+
 (defmethod tell :before ((cmd (eql 'BITCOUNT)) &rest args)
   (assert (or (null (second args)) (third args))))
 

--- a/test.lisp
+++ b/test.lisp
@@ -475,6 +475,10 @@
             (red-bitcount "mykey"))
     (should be = 16
             (red-bitop "NOT" "mykey2" "mykey"))
+    (should be equal '("1" "1")
+	    (red-bitfield "bitfield:test" "incrby" "u2" 100 1 "OVERFLOW" "SAT" "incrby" "u2" 102 1))
+    (should be equal '("1")
+	    (red-bitfield_ro "bitfield:test" "GET" "u2" 100))
     (should be string= "Uhis is a Redisg"
             (red-get "mykey"))
     (should be = 16


### PR DESCRIPTION
Hi @vseloved 

This PR adds [BITFIELD](https://redis.io/commands/bitfield/) (available since 3.2.0) and [BITFIELD_RO](https://redis.io/commands/bitfield/ and https://redis.io/commands/bitfield_ro/) (available since 6.0.0) to the client.

I've added tests with expected output based on expressions I ran under sbcl + Redis 6.4.2
