### PR TITLE
Include support to connect to Redis server using SSL

### DIFF
--- a/cl-redis.asd
+++ b/cl-redis.asd
@@ -9,7 +9,7 @@
   :maintainer "Vsevolod Dyomkin <vseloved@gmail.com>"
   :licence "MIT"
   :description "A fast and robust Common Lisp client for Redis"
-  :depends-on (#:rutils #:cl-ppcre #:usocket #:flexi-streams #:babel)
+  :depends-on (#:rutils #:cl-ppcre #:usocket #:flexi-streams #:babel #:cl+ssl #:trivial-gray-streams)
   :serial t
   :components ((:file "package")
                (:file "float")

--- a/connection.lisp
+++ b/connection.lisp
@@ -23,6 +23,58 @@ for debugging purposes.  The default is *STANDARD-OUTPUT*.")
 
 (defvar *connection* nil "The current Redis connection.")
 
+;; First, define the SSL stream methods
+(defmacro define-ssl-stream-methods ()
+  `(progn
+     ;; For SSL streams
+     (defmethod trivial-gray-streams:stream-clear-input ((stream cl+ssl::ssl-stream))
+       (trivial-gray-streams:stream-clear-input (cl+ssl::ssl-stream-socket stream)))
+
+     (defmethod trivial-gray-streams:stream-read-sequence
+         ((stream cl+ssl::ssl-stream) sequence start end &rest args)
+       (declare (ignore args))
+       (handler-case
+           (let ((bytes-read 0))
+             (loop while (< bytes-read (- end start))
+                   do (let ((byte (read-byte stream nil nil)))
+                        (when (null byte)
+                          (return bytes-read))
+                        (setf (elt sequence (+ start bytes-read)) byte)
+                        (incf bytes-read)))
+             bytes-read)
+         (cl+ssl::ssl-error-zero-return () bytes-read)
+         (cl+ssl::ssl-error-syscall () -1)
+         (cl+ssl::ssl-error-ssl () -1)))
+
+     (defmethod trivial-gray-streams:stream-write-sequence
+         ((stream cl+ssl::ssl-stream) sequence start end &rest args)
+       (declare (ignore args))
+       (handler-case
+           (loop for i from start below end
+                 do (write-byte (elt sequence i) stream)
+                 finally (return sequence))
+         (cl+ssl::ssl-error-zero-return () sequence)
+         (cl+ssl::ssl-error-syscall () sequence)
+         (cl+ssl::ssl-error-ssl () sequence)))
+
+     ;; For regular fd-streams
+     (defmethod trivial-gray-streams:stream-clear-input ((stream sb-sys:fd-stream))
+       (sb-impl::clear-input stream))
+
+     (defmethod trivial-gray-streams:stream-read-sequence
+         ((stream sb-sys:fd-stream) sequence start end &rest args)
+       (declare (ignore args))
+       (read-sequence sequence stream :start start :end end))
+
+     (defmethod trivial-gray-streams:stream-write-sequence
+         ((stream sb-sys:fd-stream) sequence start end &rest args)
+       (declare (ignore args))
+       (write-sequence sequence stream :start start :end end)
+       sequence)))
+
+;; Execute the macro to define the methods
+(define-ssl-stream-methods)
+
 (defclass redis-connection ()
   ((host
     :initarg  :host
@@ -41,7 +93,27 @@ for debugging purposes.  The default is *STANDARD-OUTPUT*.")
     :accessor conn-socket)
    (stream
     :initform nil
-    :accessor conn-stream))
+    :accessor conn-stream)
+   (ssl
+    :initarg :ssl
+    :initform nil
+    :reader conn-ssl)
+   (verify
+    :initarg :verify
+    :initform nil
+    :reader conn-verify)
+   (certificate
+    :initarg :certificate
+    :initform nil
+    :reader conn-certificate)
+   (key
+    :initarg :key
+    :initform nil
+    :reader conn-key)
+   (cipher-list
+    :initarg :cipher-list
+    :initform nil
+    :reader conn-cipher-list))
   (:documentation "Representation of a Redis connection."))
 
 (defmethod initialize-instance :after ((conn redis-connection) &key)
@@ -59,15 +131,23 @@ for debugging purposes.  The default is *STANDARD-OUTPUT*.")
 (defun open-connection (conn)
   "Create a socket connection to the host and port of CONNECTION and
 set the socket of CONN to the associated socket."
-  (setf (conn-stream conn)
-        (flex:make-flexi-stream (usocket:socket-stream
-                                 (setf (conn-socket conn)
-                                       (usocket:socket-connect
-                                        (conn-host conn) (conn-port conn)
-                                        :element-type 'flex:octet)))
-                                :external-format +utf8+
-                                #-lispworks :element-type
-                                #-lispworks 'flex:octet))
+  (let ((socket (usocket:socket-connect (conn-host conn) (conn-port conn)
+                                         :element-type 'flex:octet)))
+    (setf (conn-socket conn) socket)
+    (let ((socket-stream (usocket:socket-stream socket)))
+      (setf (conn-stream conn)
+            (flex:make-flexi-stream
+             (if (conn-ssl conn)
+                 (cl+ssl:make-ssl-client-stream
+                  socket-stream
+                  :verify (conn-verify conn)
+                  :certificate (conn-certificate conn)
+                  :key (conn-key conn)
+                  :cipher-list (conn-cipher-list conn))
+                 socket-stream)
+             :external-format +utf8+
+             #-lispworks :element-type
+             #-lispworks 'flex:octet))))
   (when (conn-auth conn)
     (let ((*connection* conn)) ; AUTH needs *CONNECTION* to be bound
                                ; to the current connection.  At this
@@ -95,7 +175,14 @@ Redis socket: ~A" e)))))
   "Is there a current connection?"
   (and *connection* (connection-open-p *connection*)))
 
-(defun connect (&key (host #(127 0 0 1)) (port 6379) auth)
+(defun connect (&key (host #(127 0 0 1))
+                     (port 6379)
+                     auth
+                     ssl
+                     verify
+                     certificate
+                     key
+                     cipher-list)
   "Connect to Redis server."
   (when (connected-p)
     (restart-case (error 'redis-error
@@ -107,7 +194,14 @@ Redis socket: ~A" e)))))
         :report "Replace it with a new connection."
         (disconnect))))
   (setf *connection* (make-instance 'redis-connection
-                                    :host host :port port :auth auth)))
+                                    :host host
+                                    :port port
+                                    :auth auth
+                                    :ssl ssl
+                                    :verify verify
+                                    :certificate certificate
+                                    :key key
+                                    :cipher-list cipher-list)))
 
 
 (defun disconnect ()
@@ -122,12 +216,24 @@ Redis socket: ~A" e)))))
 
 (defmacro with-connection ((&key (host #(127 0 0 1))
                                  (port 6379)
-                                 auth)
+                                 auth
+                                 ssl
+                                 verify
+                                 certificate
+                                 key
+                                 cipher-list)
                            &body body)
   "Evaluate BODY with the current connection bound to a new connection
 specified by the given HOST and PORT"
   `(let ((*connection* (make-instance 'redis-connection
-                                      :host ,host :port ,port :auth ,auth)))
+                                      :host ,host
+                                      :port ,port
+                                      :auth ,auth
+                                      :ssl ,ssl
+                                      :verify ,verify
+                                      :certificate ,certificate
+                                      :key ,key
+                                      :cipher-list ,cipher-list)))
      (unwind-protect (progn ,@body)
        (disconnect))))
 
@@ -173,23 +279,47 @@ the conenction is re-established."
 
 (defmacro with-recursive-connection ((&key (host #(127 0 0 1))
                                            (port 6379)
-                                           auth)
+                                           auth
+                                           ssl
+                                           verify
+                                           certificate
+                                           key
+                                           cipher-list)
                                      &body body)
   "Execute BODY with *CONNECTION* bound to the default Redis
 connection. If connection is already established, reuse it."
   `(if (connected-p)
        (progn ,@body)
-       (with-connection (:host ,host :port ,port :auth ,auth)
+       (with-connection (:host ,host
+                         :port ,port
+                         :auth ,auth
+                         :ssl ,ssl
+                         :verify ,verify
+                         :certificate ,certificate
+                         :key ,key
+                         :cipher-list ,cipher-list)
          ,@body)))
 
 (defmacro with-persistent-connection ((&key (host #(127 0 0 1))
                                             (port 6379)
-                                            auth)
+                                            auth
+                                            ssl
+                                            verify
+                                            certificate
+                                            key
+                                            cipher-list)
                                       &body body)
   "Execute BODY inside WITH-CONNECTION. But if connection is broken
 due to REDIS-CONNECTION-ERROR (a network error or timeout),
 transparently reopen it."
-  `(with-connection (:host ,host :port ,port :auth ,auth)
+  `(with-connection (:host ,host
+                     :port ,port
+                     :auth ,auth
+                     :ssl ,ssl
+                     :verify ,verify
+                     :certificate ,certificate
+                     :key ,key
+                     :cipher-list ,cipher-list)
      (handler-bind ((redis-connection-error
                      (lambda (e)
                        (declare (ignore e))


### PR DESCRIPTION
Hello,

Attempted to use the cl-redis package to connect to a serverless AWS Redis instance. However, while the connection is established, traffic was not being exchanged due to AWS Redis requiring SSL/TLS.

While an option to setup some kind of SSL tunnel at the OS-level is availalble (e.g. stunnels), having support for SSL connections within the package is highly desirable.

Please consider adding SSL support or accepting my changes.

Thank you